### PR TITLE
3 changes made see comment

### DIFF
--- a/src/d2r-map.ahk
+++ b/src/d2r-map.ahk
@@ -37,6 +37,7 @@ IniRead, normalMobColor, settings.ini, MapSettings, normalMobColor, "FFFFFF"
 IniRead, uniqueMobColor, settings.ini, MapSettings, uniqueMobColor, "D4AF37"
 IniRead, showOverlayWhenInGameMapHidden, settings.ini, MapSettings, showOverlayWhenInGameMapHidden, "false"
 
+
 IniRead, startingOffset, settings.ini, Memory, playerOffset
 IniRead, uiOffset, settings.ini, Memory, uiOffset
 IniRead, readInterval, settings.ini, Memory, readInterval, 1000
@@ -67,6 +68,8 @@ alwaysShowMap := alwaysShowMap = "true" ; convert to bool
 debug := debug = "true" ; convert to bool
 showNormalMobs := showNormalMobs = "true" ; convert to bool
 showUniqueMobs := showUniqueMobs = "true" ; convert to bool
+showOverlayWhenInGameMapHidden := showOverlayWhenInGameMapHidden = "true"
+
 global debug := debug
 global gameWindowId := gameWindowId
 mapConfig := {"showNormalMobs": showNormalMobs, "showUniqueMobs": showUniqueMobs, "normalMobColor": normalMobColor, "uniqueMobColor": uniqueMobColor}
@@ -112,11 +115,12 @@ While 1 {
                 ;Gui, 1: Show, NA
                 ;Gui, 3: Show, NA
                 ShowMap(maxWidth, scale, leftMargin, topMargin, opacity, mapData, gameMemoryData, uiData)
-                checkAutomapVisibility(uiOffset, alwaysShowMap, hideTown, gameMemoryData["levelNo"])
+				
+                checkAutomapVisibility(uiOffset, alwaysShowMap, hideTown, gameMemoryData["levelNo"], showOverlayWhenInGameMapHidden)
             }
 
             ShowPlayer(maxWidth, scale, leftMargin, topMargin, mapConfig, mapData, gameMemoryData, uiData)
-            checkAutomapVisibility(uiOffset, alwaysShowMap, hideTown, gameMemoryData["levelNo"])
+            checkAutomapVisibility(uiOffset, alwaysShowMap, hideTown, gameMemoryData["levelNo"], showOverlayWhenInGameMapHidden)
 
             lastlevel := gameMemoryData["levelNo"]
         } else {
@@ -129,18 +133,39 @@ While 1 {
 
 
 
-checkAutomapVisibility(uiOffset, alwaysShowMap, hideTown, levelNo) {
+checkAutomapVisibility(uiOffset, alwaysShowMap, hideTown, levelNo, showOverlayWhenInGameMapHidden) {
+	
     ;WriteLogDebug("Checking visibility, hideTown: " hideTown " alwaysShowMap: " alwaysShowMap)
     if ((levelNo == 1 or levelNo == 40 or levelNo == 75 or levelNo == 103 or levelNo == 109) and hideTown==true) {
         ;WriteLogDebug("Hiding town " levelNo " since hideTown is set to true")
         hideMap(false)
-    } else if not WinActive(gameWindowId) {
-        ;WriteLogDebug("D2R is not active window, hiding map")
-        hideMap(true)
-    } else if (isAutomapShown(uiOffset) == false and showOverlayWhenInGameMapHidden == false) {
-        ; hidemap
-        hideMap(alwaysShowMap)
     } 
+	else if not WinActive(gameWindowId) {
+        ;WriteLogDebug("D2R is not active window, hiding map")
+        hideMap(false)
+    } 
+	else if (showOverlayWhenInGameMapHidden == false) {
+			if (isAutomapShown(uiOffset) == false) {
+				; hidemap
+				hideMap(alwaysShowMap)
+			}
+			else {
+				unHideMap()
+			}
+		}
+		else if (showOverlayWhenInGameMapHidden == true) {
+			if (isAutomapShown(uiOffset) == true) {
+				; hidemap
+				hideMap(alwaysShowMap)
+			}
+			else {
+				unHideMap()
+			}
+		
+		
+    }
+		
+	
     else {
         unHideMap()
     } 
@@ -165,7 +190,7 @@ unHideMap() {
 ~TAB::
 ~Space::
 {
-    checkAutomapVisibility(uiOffset, alwaysShowMap, hideTown, gameMemoryData["levelNo"])
+    checkAutomapVisibility(uiOffset, alwaysShowMap, hideTown, gameMemoryData["levelNo"], showOverlayWhenInGameMapHidden)
     return
 }
 

--- a/src/d2r-map.ahk
+++ b/src/d2r-map.ahk
@@ -40,11 +40,17 @@ IniRead, startingOffset, settings.ini, Memory, playerOffset
 IniRead, uiOffset, settings.ini, Memory, uiOffset
 IniRead, readInterval, settings.ini, Memory, readInterval, 1000
 
-IniRead, enableD2ML, settings.ini, MultiLaunch, enableD2ML
-if (enableD2ML == "true") {
+IniRead, enableD2ML, settings.ini, MultiLaunch, "false"
+IniRead, enableCustomWindowTitle, settings.ini, MultiLaunch, "false"
+if (enableCustomWindowTitle == "true") {
+    IniRead, windowName, settings.ini, MultiLaunch, windowName
+    gameWindowId = %windowName%
+}
+else if (enableD2ML == "true") {
     IniRead, tokenName, settings.ini, MultiLaunch, tokenName
     gameWindowId = D2R:%tokenName%
-} else {
+} 
+else {
     gameWindowId := "ahk_exe D2R.exe"
 }
 

--- a/src/d2r-map.ahk
+++ b/src/d2r-map.ahk
@@ -35,6 +35,7 @@ IniRead, showNormalMobs, settings.ini, MapSettings, showNormalMobs, "true"
 IniRead, showUniqueMobs, settings.ini, MapSettings, showUniqueMobs, "true"
 IniRead, normalMobColor, settings.ini, MapSettings, normalMobColor, "FFFFFF"
 IniRead, uniqueMobColor, settings.ini, MapSettings, uniqueMobColor, "D4AF37"
+IniRead, showOverlayWhenInGameMapHidden, settings.ini, MapSettings, showOverlayWhenInGameMapHidden, "false"
 
 IniRead, startingOffset, settings.ini, Memory, playerOffset
 IniRead, uiOffset, settings.ini, Memory, uiOffset
@@ -53,6 +54,9 @@ else if (enableD2ML == "true") {
 else {
     gameWindowId := "ahk_exe D2R.exe"
 }
+
+
+
 
 
 IniRead, debug, settings.ini, Logging, debug, "false"
@@ -132,11 +136,12 @@ checkAutomapVisibility(uiOffset, alwaysShowMap, hideTown, levelNo) {
         hideMap(false)
     } else if not WinActive(gameWindowId) {
         ;WriteLogDebug("D2R is not active window, hiding map")
-        hideMap(alwaysShowMap)
-    } else if (isAutomapShown(uiOffset) == false) {
+        hideMap(true)
+    } else if (isAutomapShown(uiOffset) == false and showOverlayWhenInGameMapHidden == false) {
         ; hidemap
         hideMap(alwaysShowMap)
-    } else {
+    } 
+    else {
         unHideMap()
     } 
     return

--- a/src/d2r-map.ahk
+++ b/src/d2r-map.ahk
@@ -41,8 +41,8 @@ IniRead, startingOffset, settings.ini, Memory, playerOffset
 IniRead, uiOffset, settings.ini, Memory, uiOffset
 IniRead, readInterval, settings.ini, Memory, readInterval, 1000
 
-IniRead, enableD2ML, settings.ini, MultiLaunch, "false"
-IniRead, enableCustomWindowTitle, settings.ini, MultiLaunch, "false"
+IniRead, enableD2ML, settings.ini, MultiLaunch, enableD2ML, "false"
+IniRead, enableCustomWindowTitle, settings.ini, MultiLaunch, enableCustomWindowTitle, "false"
 if (enableCustomWindowTitle == "true") {
     IniRead, windowName, settings.ini, MultiLaunch, windowName
     gameWindowId = %windowName%

--- a/src/settings.ini
+++ b/src/settings.ini
@@ -22,8 +22,8 @@ opacity=0.5
 alwaysShowMap=false
 hideTown=false
 
-; changing showMapWhenInGameMapHidden to true will show the Overlay when the in-game minimap is hidden
-showMapWhenInGameMapHidden=false
+; changing showOverlayWhenInGameMapHidden to true will show the Overlay when the in-game minimap is hidden
+showOverlayWhenInGameMapHidden=false
 
 showNormalMobs=true
 showUniqueMobs=true

--- a/src/settings.ini
+++ b/src/settings.ini
@@ -45,6 +45,11 @@ tokenName=main
 ; then update that settings ini to the 2nd or 3rd token
 
 
+; use these variables to enter your own custom window title
+enableCustomWindowTitle=false
+windowName=customWindowName 
+
+
 
 [Logging]
 debug=true

--- a/src/settings.ini
+++ b/src/settings.ini
@@ -22,6 +22,9 @@ opacity=0.5
 alwaysShowMap=false
 hideTown=false
 
+; changing showMapWhenInGameMapHidden to true will show the Overlay when the in-game minimap is hidden
+showMapWhenInGameMapHidden=false
+
 showNormalMobs=true
 showUniqueMobs=true
 normalMobColor=FFFFFF


### PR DESCRIPTION
1) added showOverlayWhenInGameMapHidden to settings and main source file. when set to true in settings.ini, this shows the Overlay when the in-game minimap is HIDDEN (opposite of default behavior. Default behavior is unchanged)

2) Added support for custom window titles (see settings.ini section under Multi-Launch)

3) you made alwaysShowMap show made ALWAYS, even when im alt tabbed on google chrome
i think behavior of that should be showoverlay ALWAYS while in game, but continue to suppress overlay outside of game
i dont know if your behavior was intentional, if it was feel free to delete that commit