### PR TITLE
Individual map config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ log.txt
 /bin/currentmap.png
 currentmap.png
 /src/debug.ahk
+/src/mapconfig.ini

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 All notable changes to this project will be documented in this file.
 
+## [2.2.5] - 2021-12-03 - Individual map sizes and positions
+
+Map position changes:
+
+- Now each level keeps it's own position and scale on the screen.
+- You can change the scale with `Numpad+` and `Numpad-`, (you can configure different keys)
+- To _move_ the map, press `Windows Key+Left` `Windows Key+Right` `Windows Key+Up` `Windows Key+Down`
+- Map movement keys are not yet configurable
+- Map location and scale for each map are saved in a new file `mapconfig.ini`
+- The first time you run this version, a new `mapconfig.ini` file will be created with default values.
+- If you have an existing `mapconfig.ini` it will not be overwritten, so you can keep your settings for future releases.
+- The default values are not ideal, but in the next release I'll include better defaults (I need someone to manually configure every map)
+- Normal `scale` and `leftMargin`/`topMargin` settings in `settings.ini` still work but will apply to ALL maps.  
+  The individual map scale and location are relative to these values.  
+  So if you set global scale `1.5` and an individual map scale is `1.2` then the actual scale is `1.5 x 1.2` (1.8).  
+
+Other changes:
+
+- Removed `maxWidth` setting as it didn't make sense anymore  
+- Added the ability to turn off other players on the map `showOtherPlayers=true` in `settings.ini`
+- Other minor tweaks for performance
+
 ## [2.2.4] - 2021-12-03 - Updated offsets
 
 - Updated offests following patch `1.167314`

--- a/README.md
+++ b/README.md
@@ -57,26 +57,19 @@ This server is getting hammered lately so it would be appreciated if you support
 
 - Live player position on map
 - Live monster position on map
-- Unique/champion monsters live location marked on map
+- Other player positions on map
+- Unique/champion monsters marked specially
+- Immunities of monsters highlighted
 - Super chests specially marked (LK chests)
 - All quest items, doors, waypoints marked
-- Line drawn from your player position to the next level
+- Line drawn from your player position to the next level/waypoint
+- Highly configurable
 
-If you want server IP to show, look at my extra standalone tool for that <https://github.com/joffreybesos/DcloneIPview>
-
-**Map Legend**
-
-- Green dot for player position
-- White dots for normal monsters
-- Large yellow dot for unique monsters
-- Purple square for exits
-- Yellow square for waypoints
-- Most quest items should be marked with their respective icons
-- Special unique monsters such as Radament and Summoner should have large red dots on their spawn location
+If you want D2R server IP to show, look at my extra standalone tool for that <https://github.com/joffreybesos/DcloneIPview>
 
 **Other notes**
 
-- Press Ctrl+H to see help in game
+- Press Ctrl+H to see help in game, including a map legend
 - You can exit the maphack with Shift+F10
 - You can also right click the icon in the system tray.
 - This MH will automatically exit when you exit D2R.
@@ -103,21 +96,32 @@ In `settings.ini` you should see some options to make configuration changes.
 | Setting |     Default     |    Description    |
 | :-------------- | :------------------ | :---------------------- |
 | baseUrl | http://localhost:3002 | URL of the map server, set to public server by default, but you can use localhost if you [run your own server](SERVER.md) |
-| maxWidth | 2000 | Maximum map image width in pixels, prevents oversized maps covering too much of the screen |
-| scale | 1.1 | The global scale setting applied to all map images, press NumpadPlus and NumpadSubtract to adjust in game|
-| leftMargin | 20 | The left margin of the map image, set this to wider than your primary monitor to push it onto your secondary monitor. |
+| scale | 1.0 | The global scale setting applied to all map images, press NumpadPlus and NumpadSubtract to adjust in game|
+| leftMargin | 20 | The left margin of all map images, set this to wider than your primary monitor to push it onto your secondary monitor. |
 | topMargin | 20 | Top margin of map image |
 | opacity | 0.5 | How transparent the map image should be, between 0 and 1 |
-| alwaysShowMap | false | You can show hide map with TAB key, this setting will force it to always show |
+| alwaysShowMap | false | This setting will force the map to always show, ignoring the TAB key |
 | hideTown | false | This will hide town maps so they will never show |
 | showNormalMobs | true | Set to false to hide normal non-unique monsters on the map |
 | showUniqueMobs | true | Set to false to hide unique monsters on the map |
+| showBosses | true | Show bosses with a red dot, such as Diablo, Summoner etc |
+| showDeadMobs | true | Show dead mobs as a black square (useful to know which areas are clear) |
 | normalMobColor | FFFFFF | Colour of the dot of normal monsters |
 | uniqueMobColor | D4AF37 | Colour of the dot of unique monsters |
+| bossColor | FF0000 | Colour of boss dots on the map |
+| showImmunuties | true | Show immunties of normal and unique monsters |
+| showWaypointLine | false | Draws a yellow line to the nearest waypoint, turned off by default |
+| showNextExitLine | true | Draws a purple line to the next relevant exit |
+| showBossLine | true | Draws a red line to the boss in that level (Nihlithak, Summoner etc) |
+| increaseMapSizeKey | NumpadAdd | Key to increase the size of the map |
+| decreaseMapSizeKey | NumpadSub | Key to decrease the size of the map |
+| alwaysShowKey | NumpadMult | Key to toggle `alwaysShowMap` setting |
 | playerOffset | 0x20AF660 | The static memory offset, when a new D2R client is released this will need to be updated |
 | uiOffset | 0x20BF322 | The offset used to determine whether your minimap is open or not |
 | readInterval |  10| How long to sleep between memory reads. Increase this if you are having performance problems |
-| debug| false | Turn this one to increase the level of the logging, note this will create huse `log.txt` files |
+| enableD2ML | false | Only enable if you use multiple D2R sessions, not tested well |
+| windowTitle | D2R:main | this is ignored unless `enableD2ML` is turned on. It is the window title of one D2R session for multi sesion |
+| debug| false | Turn this one to increase the level of the logging, note this will create huge `log.txt` files |
 
 ## Map Server
 

--- a/src/d2r-map.ahk
+++ b/src/d2r-map.ahk
@@ -68,7 +68,7 @@ While 1 {
         }
         Sleep, 5000 ; sleep longer when no offset found, you're likely in menu
     } else {
-        readGameMemory(playerOffset, startingOffset, gameMemoryData)
+        readGameMemory(settings, playerOffset, gameMemoryData)
 
         if ((gameMemoryData["difficulty"] > 0 & gameMemoryData["difficulty"] < 3) and (gameMemoryData["levelNo"] > 0 and gameMemoryData["levelNo"] < 137) and gameMemoryData["mapSeed"]) {
             if (gameMemoryData["mapSeed"] != lastSeed) {
@@ -171,31 +171,31 @@ MapSizeAlwaysShow:
 
 MapSizeIncrease:
 {
-    settings["scale"] := settings["scale"] + 0.1
-    if (settings["scale"] > 5.0) {
-        WriteLog("Scale is larger than max scale of 5: " settings["scale"])
-        settings["scale"] := 5.0
+    levelNo := gameMemoryData["levelNo"]
+    levelScale := mapData["levelScale"]
+    if (levelNo and levelScale) {
+        levelScale := levelScale + 0.1
+        IniWrite, %levelScale%, mapconfig.ini, %levelNo%, scale
+        mapData["levelScale"] := levelScale
+        ShowMap(settings, mapData, gameMemoryData, uiData)
+        ShowPlayer(settings, mapData, gameMemoryData, uiData)
+        WriteLog("Increased level " levelNo " scale by 0.1 to " levelScale)
     }
-    ShowMap(settings, mapData, gameMemoryData, uiData)
-    ShowPlayer(settings, mapData, gameMemoryData, uiData)
-    scale := settings["scale"]
-    IniWrite, %scale%, settings.ini, MapSettings, scale
-    WriteLog("Increased scaled by 0.1 to " scale)
     return
 }
 
 MapSizeDecrease:
 {
-    settings["scale"] := settings["scale"] - 0.1
-    if (settings["scale"] < 0.2) {
-        WriteLog("Scale is lower than minimum scale 0.2: " settings["scale"])
-        settings["scale"] := 0.2
+    levelNo := gameMemoryData["levelNo"]
+    levelScale := mapData["levelScale"]
+    if (levelNo and levelScale) {
+        levelScale := levelScale - 0.1
+        IniWrite, %levelScale%, mapconfig.ini, %levelNo%, scale
+        mapData["levelScale"] := levelScale
+        ShowMap(settings, mapData, gameMemoryData, uiData)
+        ShowPlayer(settings, mapData, gameMemoryData, uiData)
+        WriteLog("Decreased level " levelNo " scale by 0.1 to " levelScale)
     }
-    ShowMap(settings, mapData, gameMemoryData, uiData)
-    ShowPlayer(settings, mapData, gameMemoryData, uiData)
-    scale := settings["scale"]
-    IniWrite, %scale%, settings.ini, MapSettings, scale
-    WriteLog("Decreased scaled by 0.1 to " scale)
     return
 }
     

--- a/src/d2r-map.ahk
+++ b/src/d2r-map.ahk
@@ -174,12 +174,12 @@ MapSizeIncrease:
     levelNo := gameMemoryData["levelNo"]
     levelScale := mapData["levelScale"]
     if (levelNo and levelScale) {
-        levelScale := levelScale + 0.1
+        levelScale := levelScale + 0.05
         IniWrite, %levelScale%, mapconfig.ini, %levelNo%, scale
         mapData["levelScale"] := levelScale
         ShowMap(settings, mapData, gameMemoryData, uiData)
         ShowPlayer(settings, mapData, gameMemoryData, uiData)
-        WriteLog("Increased level " levelNo " scale by 0.1 to " levelScale)
+        WriteLog("Increased level " levelNo " scale by 0.05 to " levelScale)
     }
     return
 }
@@ -189,17 +189,73 @@ MapSizeDecrease:
     levelNo := gameMemoryData["levelNo"]
     levelScale := mapData["levelScale"]
     if (levelNo and levelScale) {
-        levelScale := levelScale - 0.1
+        levelScale := levelScale - 0.05
         IniWrite, %levelScale%, mapconfig.ini, %levelNo%, scale
         mapData["levelScale"] := levelScale
         ShowMap(settings, mapData, gameMemoryData, uiData)
         ShowPlayer(settings, mapData, gameMemoryData, uiData)
-        WriteLog("Decreased level " levelNo " scale by 0.1 to " levelScale)
+        WriteLog("Decreased level " levelNo " scale by 0.05 to " levelScale)
     }
     return
 }
     
 #IfWinActive, ahk_exe D2R.exe
+    #Left::
+    {
+        levelNo := gameMemoryData["levelNo"]
+        levelxmargin := mapData["levelxmargin"]
+        levelymargin := mapData["levelymargin"]
+        if (levelNo) {
+            levelxmargin := levelxmargin - 25
+            IniWrite, %levelxmargin%, mapconfig.ini, %levelNo%, x
+            mapData["levelxmargin"] := levelxmargin
+            ShowMap(settings, mapData, gameMemoryData, uiData)
+            ShowPlayer(settings, mapData, gameMemoryData, uiData)
+        }
+        return
+    }
+    #Right::
+    {
+        levelNo := gameMemoryData["levelNo"]
+        levelxmargin := mapData["levelxmargin"]
+        levelymargin := mapData["levelymargin"]
+        if (levelNo) {
+            levelxmargin := levelxmargin + 25
+            IniWrite, %levelxmargin%, mapconfig.ini, %levelNo%, x
+            mapData["levelxmargin"] := levelxmargin
+            ShowMap(settings, mapData, gameMemoryData, uiData)
+            ShowPlayer(settings, mapData, gameMemoryData, uiData)
+        }
+        return
+    }
+    #Up::
+    {
+        levelNo := gameMemoryData["levelNo"]
+        levelxmargin := mapData["levelxmargin"]
+        levelymargin := mapData["levelymargin"]
+        if (levelNo) {
+            levelymargin := levelymargin - 25
+            IniWrite, %levelymargin%, mapconfig.ini, %levelNo%, y
+            mapData["levelymargin"] := levelymargin
+            ShowMap(settings, mapData, gameMemoryData, uiData)
+            ShowPlayer(settings, mapData, gameMemoryData, uiData)
+        }
+        return
+    }
+    #Down::
+    {
+        levelNo := gameMemoryData["levelNo"]
+        levelxmargin := mapData["levelxmargin"]
+        levelymargin := mapData["levelymargin"]
+        if (levelNo) {
+            levelymargin := levelymargin + 25
+            IniWrite, %levelymargin%, mapconfig.ini, %levelNo%, y
+            mapData["levelymargin"] := levelymargin
+            ShowMap(settings, mapData, gameMemoryData, uiData)
+            ShowPlayer(settings, mapData, gameMemoryData, uiData)
+        }
+        return
+    }
     ^H::
     {
         if (helpToggle) {

--- a/src/mapconfig-default.ini
+++ b/src/mapconfig-default.ini
@@ -1,103 +1,103 @@
 [1]
 ;Rogue Encampment
-x=-150
-y=-50
-scale=1.000000
+x=-205
+y=-65
+scale=1.150000
 
 [2]
 ;Blood Moor
-x=-250
-y=-170
-scale=1.100000
+x=-280
+y=-155
+scale=1.350000
 
 [3]
 ;Cold Plains
-x=-200
-y=-50
-scale=1.100000
+x=-100
+y=-80
+scale=1.250000
 
 [4]
 ;Stony Field
-x=-200
-y=-50
-scale=0.900000
+x=-395
+y=-270
+scale=1.500000
 
 [5]
 ;Dark Wood
-x=-200
-y=-50
-scale=0.900000
+x=-270
+y=-195
+scale=1.350000
 
 [6]
 ;Black Marsh
-x=-200
-y=-50
-scale=1.100000
+x=-175
+y=-120
+scale=1.350000
 
 [7]
 ;Tamoe Highland
-x=-200
-y=-50
-scale=1.2
+x=-125
+y=-70
+scale=1.300000
 
 [8]
 ;Den of Evil
-x=-200
-y=-50
-scale=1.2
+x=-250
+y=-170
+scale=1.450000
 
 [9]
 ;Cave Level 1
 x=-200
-y=-50
-scale=1.2
+y=-170
+scale=1.400000
 
 [10]
 ;Underground Passage Level 1
-x=-200
-y=-50
+x=-300
+y=-95
 scale=1.2
 
 [11]
 ;Hole Level 1
-x=-200
-y=-50
+x=-100
+y=-20
 scale=1.2
 
 [12]
 ;Pit Level 1
-x=-200
-y=-50
+x=-100
+y=-20
 scale=1.2
 
 [13]
 ;Cave Level 2
 x=-200
-y=-50
-scale=1.2
+y=-95
+scale=1.800000
 
 [14]
 ;Underground Passage Level 2
-x=-200
-y=-50
-scale=1.2
+x=-225
+y=-95
+scale=1.750000
 
 [15]
 ;Hole Level 2
-x=-200
-y=-50
+x=-100
+y=-20
 scale=1.2
 
 [16]
 ;Pit Level 2
-x=-200
-y=-50
+x=-100
+y=-20
 scale=1.2
 
 [17]
 ;Burial Grounds
-x=-200
-y=-50
+x=-100
+y=-20
 scale=1.2
 
 [18]
@@ -108,684 +108,690 @@ scale=1.400000
 
 [19]
 ;Mausoleum
-x=-200
-y=-50
+x=-100
+y=-20
 scale=1.2
 
 [20]
 ;Forgotten Tower
-x=-200
-y=-50
+x=-100
+y=-20
 scale=1.2
 
 [21]
 ;Tower Cellar Level 1
-x=-300
-y=-100
-scale=1.400000
+x=-250
+y=-200
+scale=1.850000
 
 [22]
 ;Tower Cellar Level 2
-x=-300
-y=-100
-scale=1.400000
+x=-250
+y=-200
+scale=1.850000
 
 [23]
 ;Tower Cellar Level 3
-x=-300
-y=-100
-scale=1.400000
+x=-250
+y=-200
+scale=1.850000
 
 [24]
 ;Tower Cellar Level 4
-x=-300
-y=-100
-scale=1.400000
+x=-250
+y=-200
+scale=1.850000
 
 [25]
 ;Tower Cellar Level 5
-x=-300
-y=-100
-scale=1.400000
+x=-250
+y=-200
+scale=1.850000
 
 [26]
 ;Monastery Gate
-x=-200
-y=-50
-scale=1.2
+x=-125
+y=-45
+scale=1.300000
 
 [27]
 ;Outer Cloister
-x=-200
-y=-50
-scale=1.2
+x=-125
+y=-70
+scale=1.350000
 
 [28]
 ;Barracks
-x=-200
-y=-50
-scale=1.2
+x=-275
+y=-145
+scale=1.600000
 
 [29]
 ;Jail Level 1
-x=-200
-y=-50
-scale=1.300000
+x=-275
+y=-145
+scale=1.600000
 
 [30]
 ;Jail Level 2
-x=-200
-y=-50
-scale=1.2
+x=-275
+y=-145
+scale=1.6
 
 [31]
 ;Jail Level 3
-x=-200
-y=-50
-scale=1.2
+x=-275
+y=-145
+scale=1.6
 
 [32]
 ;Inner Cloister
-x=-200
-y=-50
-scale=1.2
+x=-150
+y=-45
+scale=1.700000
 
 [33]
 ;Cathedral
-x=-200
-y=-50
+x=-100
+y=-20
 scale=1.2
 
 [34]
 ;Catacombs Level 1
-x=-200
-y=-50
-scale=1.2
+x=-225
+y=-195
+scale=1.700000
 
 [35]
 ;Catacombs Level 2
-x=-200
-y=-50
-scale=1.2
+x=-225
+y=-195
+scale=1.700000
 
 [36]
 ;Catacombs Level 3
-x=-200
-y=-50
-scale=1.2
+x=-225
+y=-195
+scale=1.700000
 
 [37]
 ;Catacombs Level 4
-x=-200
-y=-50
-scale=1.2
+x=-225
+y=-195
+scale=1.700000
 
 [38]
 ;Tristram
 x=-200
-y=-50
-scale=1.2
+y=-120
+scale=1.550000
 
 [39]
 ;Moo Moo Farm
-x=-200
-y=-50
+x=-100
+y=-20
 scale=1.2
 
 [40]
 ;Lut Gholein
-x=-200
-y=-50
-scale=0.900000
+x=-150
+y=-120
+scale=1.150000
 
 [41]    
 ;Rocky Waste
-x=-200
-y=-50
+x=-100
+y=-20
 scale=1.2
 
 [42]
 ;Dry Hills
-x=-200
-y=-50
-scale=1.2
+x=-205
+y=-170
+scale=1.300000
 
 [43]
 ;Far Oasis
-x=-200
-y=-50
-scale=1.2
+x=-205
+y=-170
+scale=1.300000
 
 [44]
 ;Lost City
-x=-200
-y=-50
-scale=1.2
+x=-205
+y=-170
+scale=1.300000
 
 [45]
 ;Valley of Snakes
-x=-200
-y=-50
-scale=1.2
+x=-205
+y=-170
+scale=1.300000
 
 [46]
 ;Canyon of the Magi
-x=-200
-y=-50
-scale=1.2
+x=-155
+y=-95
+scale=1.300000
 
 [47]
 ;Sewers Level 1
-x=-200
-y=-50
-scale=1.2
+x=-350
+y=-170
+scale=1.450000
 
 [48]
 ;Sewers Level 2
-x=-200
-y=-50
-scale=1.2
+x=-350
+y=-170
+scale=1.450000
 
 [49]
 ;Sewers Level 3
-x=-200
-y=-50
-scale=1.2
+x=-350
+y=-170
+scale=1.450000
 
 [50]
 ;Harem Level 1
-x=-200
-y=-50
+x=-100
+y=-20
 scale=1.2
 
 [51]
 ;Harem Level 2
-x=-200
-y=-50
+x=-100
+y=-20
 scale=1.2
 
 [52]
 ;Palace Cellar Level 1
-x=-200
-y=-50
-scale=1.2
+x=-125
+y=-45
+scale=1.750000
 
 [53]
 ;Palace Cellar Level 2
-x=-200
-y=-50
-scale=1.2
+x=-125
+y=-45
+scale=1.750000
 
 [54]
 ;Palace Cellar Level 3
-x=-200
-y=-50
-scale=1.2
+x=-125
+y=-45
+scale=1.750000
 
 [55]
 ;Stony Tomb Level 1
-x=-200
-y=-50
+x=-100
+y=-20
 scale=1.2
 
 [56]
 ;Halls of the Dead Level 1
-x=-200
-y=-50
+x=-280
+y=-155
 scale=1.2
 
 [57]
 ;Halls of the Dead Level 2
-x=-200
-y=-50
+x=-280
+y=-155
 scale=1.2
 
 [58]
 ;Claw Viper Temple Level 1
-x=-200
-y=-50
+x=-280
+y=-155
 scale=1.2
 
 [59]
 ;Stony Tomb Level 2
-x=-200
-y=-50
+x=-100
+y=-20
 scale=1.2
 
 [60]
 ;Halls of the Dead Level 3
-x=-200
-y=-50
+x=-100
+y=-20
 scale=1.2
 
 [61]
 ;Claw Viper Temple Level 2
-x=-200
-y=-50
+x=-100
+y=-20
 scale=1.2
 
 [62]
 ;Maggot Lair Level 1
-x=-200
-y=-50
-scale=1.2
+x=-250
+y=-170
+scale=1.450000
 
 [63]
 ;Maggot Lair Level 2
-x=-200
-y=-50
-scale=1.2
+x=-250
+y=-170
+scale=1.450000
 
 [64]
 ;Maggot Lair Level 3
-x=-200
-y=-50
-scale=1.2
+x=-250
+y=-170
+scale=1.450000
 
 [65]
 ;Ancient Tunnels
-x=-200
-y=-50
+x=-100
+y=-20
 scale=1.2
 
 [66]
 ;Tal Rasha's Tomb
 x=-200
-y=-50
-scale=1.2
+y=-145
+scale=1.400000
+
 
 [67]
 ;Tal Rasha's Tomb
 x=-200
-y=-50
-scale=1.2
+y=-145
+scale=1.400000
+
 
 [68]
 ;Tal Rasha's Tomb
 x=-200
-y=-50
-scale=1.2
+y=-145
+scale=1.400000
+
 
 [69]
 ;Tal Rasha's Tomb
 x=-200
-y=-50
-scale=1.2
+y=-145
+scale=1.400000
+
 
 [70]
 ;Tal Rasha's Tomb
 x=-200
-y=-50
-scale=1.2
+y=-145
+scale=1.400000
+
 
 [71]
 ;Tal Rasha's Tomb
 x=-200
-y=-50
-scale=1.2
+y=-145
+scale=1.400000
 
 [72]
 ;Tal Rasha's Tomb
 x=-200
-y=-50
-scale=1.2
+y=-145
+scale=1.400000
+
 
 [73]
 ;Duriel's Lair
-x=-200
-y=-50
+x=-100
+y=-20
 scale=1.2
 
 [74]
 ;Arcane Sanctuary
-x=-200
-y=-200
-scale=1.2
+x=-690
+y=-335
+scale=0.950000
 
 [75]
 ;Kurast Docktown
-x=-200
-y=-50
-scale=1.700000
+x=-350
+y=-195
+scale=1.750000
 
 [76]
 ;Spider Forest
 x=-200
-y=-50
-scale=1.2
+y=-145
+scale=1.100000
 
 [77]
 ;Great Marsh
-x=-200
-y=-50
-scale=1.2
+x=-100
+y=-145
+scale=1.150000
 
 [78]
 ;Flayer Jungle
-x=-200
-y=-50
+x=-150
+y=-170
 scale=1.000000
 
 [79]
 ;Lower Kurast
-x=-200
-y=-50
-scale=1.2
+x=-275
+y=-145
+scale=1.300000
 
 [80]
 ;Kurast Bazaar
-x=-200
-y=-50
-scale=1.2
+x=-185
+y=-155
+scale=1.350000
 
 [81]
 ;Upper Kurast
-x=-200
-y=-50
-scale=1.2
+x=-130
+y=-165
+scale=1.300000
 
 [82]
 ;Kurast Causeway
-x=-200
-y=-50
+x=-100
+y=-20
 scale=1.2
 
 [83]
 ;Travincal
-x=-200
-y=-50
-scale=1.2
+x=-225
+y=-195
+scale=1.550000
 
 [84]
 ;Spider Cave
-x=-200
-y=-50
+x=-100
+y=-20
 scale=1.2
 
 [85]
 ;Spider Cavern
-x=-200
-y=-50
+x=-100
+y=-20
 scale=1.2
 
 [86]
 ;Swampy Pit Level 1
-x=-200
-y=-50
+x=-100
+y=-20
 scale=1.2
 
 [87]
 ;Swampy Pit Level 2
-x=-200
-y=-50
+x=-100
+y=-20
 scale=1.2
 
 [88]
 ;Flayer Dungeon Level 1
-x=-200
-y=-50
+x=-100
+y=-20
 scale=1.2
 
 [89]
 ;Flayer Dungeon Level 2
-x=-200
-y=-50
+x=-100
+y=-20
 scale=1.2
 
 [90]
 ;Swampy Pit Level 3
-x=-200
-y=-50
+x=-100
+y=-20
 scale=1.2
 
 [91]
 ;Flayer Dungeon Level 3
-x=-200
-y=-50
+x=-100
+y=-20
 scale=1.2
 
 [92]
 ;Sewers Level 1
-x=-200
-y=-50
+x=-100
+y=-20
 scale=1.2
 
 [93]
 ;Sewers Level 2
-x=-200
-y=-50
+x=-100
+y=-20
 scale=1.2
 
 [94]
 ;Ruined Temple
-x=-200
-y=-50
+x=-100
+y=-20
 scale=1.2
 
 [95]
 ;Disused Fane
-x=-200
-y=-50
+x=-100
+y=-20
 scale=1.2
 
 [96]
 ;Forgotten Reliquary
-x=-200
-y=-50
+x=-100
+y=-20
 scale=1.2
 
 [97]
 ;Forgotten Temple
-x=-200
-y=-50
+x=-100
+y=-20
 scale=1.2
 
 [98]
 ;Ruined Fane
-x=-200
-y=-50
+x=-100
+y=-20
 scale=1.2
 
 [99]
 ;Disused Reliquary
-x=-200
-y=-50
+x=-100
+y=-20
 scale=1.2
 
 [100]
 ;Durance of Hate Level 1
-x=-200
-y=-50
-scale=1.2
+x=-225
+y=-195
+scale=1.200000
 
 [101]
 ;Durance of Hate Level 2
-x=-200
-y=-50
-scale=1.2
+x=-225
+y=-195
+scale=1.150000
 
 [102]
 ;Durance of Hate Level 3
-x=-200
-y=-50
-scale=1.2
+x=-275
+y=-170
+scale=1.500000
 
 [103]
 ;The Pandemonium Fortress
-x=-200
-y=-50
-scale=1.2
+x=-100
+y=-150
+scale=1.450000
 
 [104]
 ;Outer Steppes
 x=-200
-y=-50
-scale=1.2
+y=-220
+scale=1.400000
 
 [105]
 ;Plains of Despair
 x=-200
-y=-50
-scale=1.2
+y=-195
+scale=1.400000
 
 [106]
 ;City of the Damned
 x=-200
-y=-50
-scale=1.2
+y=-220
+scale=1.400000
 
 [107]
 ;River of Flame
-x=-200
-y=-50
-scale=1.2
+x=-250
+y=-170
+scale=1.050000
 
 [108]
 ;Chaos Sanctum
-x=-200
-y=-50
-scale=1.2
+x=-650
+y=-445
+scale=1.450000
 
 [109]
 ;Harrogath
-x=-320
-y=0
-scale=1.2
+x=-270
+y=-200
+scale=1.800000
 
 [110]
 ;Bloody Foothills
-x=-200
-y=-50
+x=-150
+y=-170
 scale=1.2
 
 [111]
 ;Rigid Highlands
-x=-200
-y=-50
-scale=1.2
+x=-205
+y=-185
+scale=1.150000
 
 [112]
 ;Arreat Plateau
-x=-200
-y=-50
+x=-225
+y=-220
 scale=1.2
 
 [113]
 ;Crystalized Cavern Level 1
-x=-200
-y=-50
-scale=1.2
+x=-260
+y=-265
+scale=1.400000
 
 [114]
 ;Cellar of Pity
-x=-200
-y=-50
-scale=1.2
+x=-125
+y=-195
+scale=1.600000
 
 [115]
 ;Crystalized Cavern Level 2
-x=-200
-y=-50
+x=-55
+y=-35
 scale=1.19999999999999
 
 [116]
 ;Echo Chamber
-x=-200
-y=-50
+x=-100
+y=-20
 scale=1.19999999999999
 
 [117]
 ;Tundra Wastelands
-x=-200
-y=-50
-scale=1.19999999999999
+x=-115
+y=-125
+scale=1.150000
 
 [118]
 ;Glacial Caves Level 1
-x=-200
-y=-50
-scale=1.19999999999999
+x=-295
+y=-180
+scale=1.350000
 
 [119]
 ;Glacial Caves Level 2
-x=-200
-y=-50
+x=-100
+y=-20
 scale=1.19999999999999
 
 [120]
 ;Rocky Summit
-x=-200
-y=-50
+x=-100
+y=-20
 scale=1.19999999999999
 
 [121]
 ;Nihlathaks Temple
-x=-200
-y=-50
+x=-100
+y=-20
 scale=1.19999999999999
 
 [122]
 ;Halls of Anguish
-x=-200
-y=-50
-scale=1.19999999999999
+x=-185
+y=-175
+scale=1.300000
 
 [123]
-;Halls of Death's Calling
-x=-60
-y=0
-scale=1.19999999999999
+;Halls of Pain
+x=-185
+y=-175
+scale=1.300000
 
 [124]
 ;Halls of Vaught
-x=-200
-y=-50
-scale=1.19999999999999
+x=-485
+y=-300
+scale=1.500000
 
 [125]
 ;Hell1
-x=-200
-y=-50
+x=-100
+y=-20
 scale=1.19999999999999
 
 [126]
 ;Hell2
-x=-200
-y=-50
+x=-100
+y=-20
 scale=1.19999999999999
 
 [127]
 ;Hell3
-x=-200
-y=-50
+x=-100
+y=-20
 scale=1.19999999999999
 
 [128]
 ;The Worldstone Keep Level 1
-x=-200
-y=-50
-scale=1.19999999999999
+x=-275
+y=-185
+scale=1.450000
 
 [129]
 ;The Worldstone Keep Level 2
-x=-200
-y=-50
-scale=1.400000
+x=-275
+y=-185
+scale=1.450000
 
 [130]
 ;The Worldstone Keep Level 3
-x=-200
-y=-50
-scale=1.400000
+x=-275
+y=-110
+scale=1.450000
 
 [131]
 ;Throne of Destruction
-x=-200
-y=-50
-scale=1.600000
+x=-175
+y=-185
+scale=1.700000
 
 [132]
 ;The Worldstone Chamber
-x=-200
-y=-50
-scale=1.19999999999999
+x=-175
+y=-185
+scale=1.450000

--- a/src/mapconfig.ini
+++ b/src/mapconfig.ini
@@ -1,0 +1,791 @@
+[1]
+;Rogue Encampment
+x=-150
+y=-50
+scale=1.000000
+
+[2]
+;Blood Moor
+x=-250
+y=-170
+scale=1.100000
+
+[3]
+;Cold Plains
+x=-200
+y=-50
+scale=1.100000
+
+[4]
+;Stony Field
+x=-200
+y=-50
+scale=0.900000
+
+[5]
+;Dark Wood
+x=-200
+y=-50
+scale=0.900000
+
+[6]
+;Black Marsh
+x=-200
+y=-50
+scale=1.100000
+
+[7]
+;Tamoe Highland
+x=-200
+y=-50
+scale=1.2
+
+[8]
+;Den of Evil
+x=-200
+y=-50
+scale=1.2
+
+[9]
+;Cave Level 1
+x=-200
+y=-50
+scale=1.2
+
+[10]
+;Underground Passage Level 1
+x=-200
+y=-50
+scale=1.2
+
+[11]
+;Hole Level 1
+x=-200
+y=-50
+scale=1.2
+
+[12]
+;Pit Level 1
+x=-200
+y=-50
+scale=1.2
+
+[13]
+;Cave Level 2
+x=-200
+y=-50
+scale=1.2
+
+[14]
+;Underground Passage Level 2
+x=-200
+y=-50
+scale=1.2
+
+[15]
+;Hole Level 2
+x=-200
+y=-50
+scale=1.2
+
+[16]
+;Pit Level 2
+x=-200
+y=-50
+scale=1.2
+
+[17]
+;Burial Grounds
+x=-200
+y=-50
+scale=1.2
+
+[18]
+;Crypt
+x=-350
+y=-80
+scale=1.400000
+
+[19]
+;Mausoleum
+x=-200
+y=-50
+scale=1.2
+
+[20]
+;Forgotten Tower
+x=-200
+y=-50
+scale=1.2
+
+[21]
+;Tower Cellar Level 1
+x=-300
+y=-100
+scale=1.400000
+
+[22]
+;Tower Cellar Level 2
+x=-300
+y=-100
+scale=1.400000
+
+[23]
+;Tower Cellar Level 3
+x=-300
+y=-100
+scale=1.400000
+
+[24]
+;Tower Cellar Level 4
+x=-300
+y=-100
+scale=1.400000
+
+[25]
+;Tower Cellar Level 5
+x=-300
+y=-100
+scale=1.400000
+
+[26]
+;Monastery Gate
+x=-200
+y=-50
+scale=1.2
+
+[27]
+;Outer Cloister
+x=-200
+y=-50
+scale=1.2
+
+[28]
+;Barracks
+x=-200
+y=-50
+scale=1.2
+
+[29]
+;Jail Level 1
+x=-200
+y=-50
+scale=1.300000
+
+[30]
+;Jail Level 2
+x=-200
+y=-50
+scale=1.2
+
+[31]
+;Jail Level 3
+x=-200
+y=-50
+scale=1.2
+
+[32]
+;Inner Cloister
+x=-200
+y=-50
+scale=1.2
+
+[33]
+;Cathedral
+x=-200
+y=-50
+scale=1.2
+
+[34]
+;Catacombs Level 1
+x=-200
+y=-50
+scale=1.2
+
+[35]
+;Catacombs Level 2
+x=-200
+y=-50
+scale=1.2
+
+[36]
+;Catacombs Level 3
+x=-200
+y=-50
+scale=1.2
+
+[37]
+;Catacombs Level 4
+x=-200
+y=-50
+scale=1.2
+
+[38]
+;Tristram
+x=-200
+y=-50
+scale=1.2
+
+[39]
+;Moo Moo Farm
+x=-200
+y=-50
+scale=1.2
+
+[40]
+;Lut Gholein
+x=-200
+y=-50
+scale=0.900000
+
+[41]    
+;Rocky Waste
+x=-200
+y=-50
+scale=1.2
+
+[42]
+;Dry Hills
+x=-200
+y=-50
+scale=1.2
+
+[43]
+;Far Oasis
+x=-200
+y=-50
+scale=1.2
+
+[44]
+;Lost City
+x=-200
+y=-50
+scale=1.2
+
+[45]
+;Valley of Snakes
+x=-200
+y=-50
+scale=1.2
+
+[46]
+;Canyon of the Magi
+x=-200
+y=-50
+scale=1.2
+
+[47]
+;Sewers Level 1
+x=-200
+y=-50
+scale=1.2
+
+[48]
+;Sewers Level 2
+x=-200
+y=-50
+scale=1.2
+
+[49]
+;Sewers Level 3
+x=-200
+y=-50
+scale=1.2
+
+[50]
+;Harem Level 1
+x=-200
+y=-50
+scale=1.2
+
+[51]
+;Harem Level 2
+x=-200
+y=-50
+scale=1.2
+
+[52]
+;Palace Cellar Level 1
+x=-200
+y=-50
+scale=1.2
+
+[53]
+;Palace Cellar Level 2
+x=-200
+y=-50
+scale=1.2
+
+[54]
+;Palace Cellar Level 3
+x=-200
+y=-50
+scale=1.2
+
+[55]
+;Stony Tomb Level 1
+x=-200
+y=-50
+scale=1.2
+
+[56]
+;Halls of the Dead Level 1
+x=-200
+y=-50
+scale=1.2
+
+[57]
+;Halls of the Dead Level 2
+x=-200
+y=-50
+scale=1.2
+
+[58]
+;Claw Viper Temple Level 1
+x=-200
+y=-50
+scale=1.2
+
+[59]
+;Stony Tomb Level 2
+x=-200
+y=-50
+scale=1.2
+
+[60]
+;Halls of the Dead Level 3
+x=-200
+y=-50
+scale=1.2
+
+[61]
+;Claw Viper Temple Level 2
+x=-200
+y=-50
+scale=1.2
+
+[62]
+;Maggot Lair Level 1
+x=-200
+y=-50
+scale=1.2
+
+[63]
+;Maggot Lair Level 2
+x=-200
+y=-50
+scale=1.2
+
+[64]
+;Maggot Lair Level 3
+x=-200
+y=-50
+scale=1.2
+
+[65]
+;Ancient Tunnels
+x=-200
+y=-50
+scale=1.2
+
+[66]
+;Tal Rasha's Tomb
+x=-200
+y=-50
+scale=1.2
+
+[67]
+;Tal Rasha's Tomb
+x=-200
+y=-50
+scale=1.2
+
+[68]
+;Tal Rasha's Tomb
+x=-200
+y=-50
+scale=1.2
+
+[69]
+;Tal Rasha's Tomb
+x=-200
+y=-50
+scale=1.2
+
+[70]
+;Tal Rasha's Tomb
+x=-200
+y=-50
+scale=1.2
+
+[71]
+;Tal Rasha's Tomb
+x=-200
+y=-50
+scale=1.2
+
+[72]
+;Tal Rasha's Tomb
+x=-200
+y=-50
+scale=1.2
+
+[73]
+;Duriel's Lair
+x=-200
+y=-50
+scale=1.2
+
+[74]
+;Arcane Sanctuary
+x=-200
+y=-200
+scale=1.2
+
+[75]
+;Kurast Docktown
+x=-200
+y=-50
+scale=1.700000
+
+[76]
+;Spider Forest
+x=-200
+y=-50
+scale=1.2
+
+[77]
+;Great Marsh
+x=-200
+y=-50
+scale=1.2
+
+[78]
+;Flayer Jungle
+x=-200
+y=-50
+scale=1.000000
+
+[79]
+;Lower Kurast
+x=-200
+y=-50
+scale=1.2
+
+[80]
+;Kurast Bazaar
+x=-200
+y=-50
+scale=1.2
+
+[81]
+;Upper Kurast
+x=-200
+y=-50
+scale=1.2
+
+[82]
+;Kurast Causeway
+x=-200
+y=-50
+scale=1.2
+
+[83]
+;Travincal
+x=-200
+y=-50
+scale=1.2
+
+[84]
+;Spider Cave
+x=-200
+y=-50
+scale=1.2
+
+[85]
+;Spider Cavern
+x=-200
+y=-50
+scale=1.2
+
+[86]
+;Swampy Pit Level 1
+x=-200
+y=-50
+scale=1.2
+
+[87]
+;Swampy Pit Level 2
+x=-200
+y=-50
+scale=1.2
+
+[88]
+;Flayer Dungeon Level 1
+x=-200
+y=-50
+scale=1.2
+
+[89]
+;Flayer Dungeon Level 2
+x=-200
+y=-50
+scale=1.2
+
+[90]
+;Swampy Pit Level 3
+x=-200
+y=-50
+scale=1.2
+
+[91]
+;Flayer Dungeon Level 3
+x=-200
+y=-50
+scale=1.2
+
+[92]
+;Sewers Level 1
+x=-200
+y=-50
+scale=1.2
+
+[93]
+;Sewers Level 2
+x=-200
+y=-50
+scale=1.2
+
+[94]
+;Ruined Temple
+x=-200
+y=-50
+scale=1.2
+
+[95]
+;Disused Fane
+x=-200
+y=-50
+scale=1.2
+
+[96]
+;Forgotten Reliquary
+x=-200
+y=-50
+scale=1.2
+
+[97]
+;Forgotten Temple
+x=-200
+y=-50
+scale=1.2
+
+[98]
+;Ruined Fane
+x=-200
+y=-50
+scale=1.2
+
+[99]
+;Disused Reliquary
+x=-200
+y=-50
+scale=1.2
+
+[100]
+;Durance of Hate Level 1
+x=-200
+y=-50
+scale=1.2
+
+[101]
+;Durance of Hate Level 2
+x=-200
+y=-50
+scale=1.2
+
+[102]
+;Durance of Hate Level 3
+x=-200
+y=-50
+scale=1.2
+
+[103]
+;The Pandemonium Fortress
+x=-200
+y=-50
+scale=1.2
+
+[104]
+;Outer Steppes
+x=-200
+y=-50
+scale=1.2
+
+[105]
+;Plains of Despair
+x=-200
+y=-50
+scale=1.2
+
+[106]
+;City of the Damned
+x=-200
+y=-50
+scale=1.2
+
+[107]
+;River of Flame
+x=-200
+y=-50
+scale=1.2
+
+[108]
+;Chaos Sanctum
+x=-200
+y=-50
+scale=1.2
+
+[109]
+;Harrogath
+x=-320
+y=0
+scale=1.2
+
+[110]
+;Bloody Foothills
+x=-200
+y=-50
+scale=1.2
+
+[111]
+;Rigid Highlands
+x=-200
+y=-50
+scale=1.2
+
+[112]
+;Arreat Plateau
+x=-200
+y=-50
+scale=1.2
+
+[113]
+;Crystalized Cavern Level 1
+x=-200
+y=-50
+scale=1.2
+
+[114]
+;Cellar of Pity
+x=-200
+y=-50
+scale=1.2
+
+[115]
+;Crystalized Cavern Level 2
+x=-200
+y=-50
+scale=1.19999999999999
+
+[116]
+;Echo Chamber
+x=-200
+y=-50
+scale=1.19999999999999
+
+[117]
+;Tundra Wastelands
+x=-200
+y=-50
+scale=1.19999999999999
+
+[118]
+;Glacial Caves Level 1
+x=-200
+y=-50
+scale=1.19999999999999
+
+[119]
+;Glacial Caves Level 2
+x=-200
+y=-50
+scale=1.19999999999999
+
+[120]
+;Rocky Summit
+x=-200
+y=-50
+scale=1.19999999999999
+
+[121]
+;Nihlathaks Temple
+x=-200
+y=-50
+scale=1.19999999999999
+
+[122]
+;Halls of Anguish
+x=-200
+y=-50
+scale=1.19999999999999
+
+[123]
+;Halls of Death's Calling
+x=-60
+y=0
+scale=1.19999999999999
+
+[124]
+;Halls of Vaught
+x=-200
+y=-50
+scale=1.19999999999999
+
+[125]
+;Hell1
+x=-200
+y=-50
+scale=1.19999999999999
+
+[126]
+;Hell2
+x=-200
+y=-50
+scale=1.19999999999999
+
+[127]
+;Hell3
+x=-200
+y=-50
+scale=1.19999999999999
+
+[128]
+;The Worldstone Keep Level 1
+x=-200
+y=-50
+scale=1.19999999999999
+
+[129]
+;The Worldstone Keep Level 2
+x=-200
+y=-50
+scale=1.400000
+
+[130]
+;The Worldstone Keep Level 3
+x=-200
+y=-50
+scale=1.400000
+
+[131]
+;Throne of Destruction
+x=-200
+y=-50
+scale=1.600000
+
+[132]
+;The Worldstone Chamber
+x=-200
+y=-50
+scale=1.19999999999999

--- a/src/memory/readGameMemory.ahk
+++ b/src/memory/readGameMemory.ahk
@@ -5,8 +5,8 @@
 #Include %A_ScriptDir%\include\logging.ahk
 SetWorkingDir, %A_ScriptDir%
 
-readGameMemory(playerOffset, startingOffset, ByRef gameMemoryData) {
-
+readGameMemory(settings, playerOffset, ByRef gameMemoryData) {
+    startingOffset := settings["playerOffset"]  ;default offset
     if (_ClassMemory.__Class != "_ClassMemory")
     {
         WriteLog("Missing classMemory.ahk dependency. Quitting")
@@ -21,7 +21,7 @@ readGameMemory(playerOffset, startingOffset, ByRef gameMemoryData) {
         WriteTimedLog()
         ExitApp
     }
-
+    
     ;WriteLog("Looking for Level No address at player offset " playerOffset)
     startingAddress := d2r.BaseAddress + playerOffset
     playerUnit := d2r.read(startingAddress, "Int64")
@@ -71,10 +71,14 @@ readGameMemory(playerOffset, startingOffset, ByRef gameMemoryData) {
     }
 
     ; get other players
-    ReadOtherPlayers(d2r, startingOffset, name, otherPlayerData)
+    if (settings["showOtherPlayers"]) {
+        ReadOtherPlayers(d2r, startingOffset, name, otherPlayerData)
+    }
 
     ; get mobs
-    ReadMobs(d2r, startingOffset, name, mobs)
+    if (settings["showNormalMobs"] or settings["showUniqueMobs"] or settings["showBosses"] or settings["showDeadMobs"]) {
+        ReadMobs(d2r, startingOffset, name, mobs)
+    }
 
     ; player position
     pPath := playerUnit + 0x38

--- a/src/readSettings.ahk
+++ b/src/readSettings.ahk
@@ -3,6 +3,8 @@ SendMode Input
 SetWorkingDir, %A_ScriptDir%
 
 readSettings(settingsFile, ByRef settings) {
+    FileInstall, mapconfig-default.ini, mapconfig.ini , 0
+
     IniRead, baseUrl, settings.ini, MapHost, baseUrl, ""
 
     IniRead, maxWidth, settings.ini, MapSettings, maxWidth, 2000
@@ -92,20 +94,19 @@ readSettings(settingsFile, ByRef settings) {
     settings.Insert("debug", debug)
 
     WriteLog("Using configuration:")
-    WriteLog(" baseUrl: " baseUrl)
-    WriteLog(" Map: maxWidth: " maxWidth ", scale: " scale ", topMargin: " topMargin ", leftMargin: " leftMargin ", opacity: " opacity)
-    WriteLog(" hideTown: " hideTown ", alwaysShowMap: " alwaysShowMap)
-    WriteLog(" showNormalMobs: " showNormalMobs " showUniqueMobs: " showUniqueMobs " showBosses: " showBosses " showDeadMobs: " showDeadMobs)
-    WriteLog(" normalMobColor: " normalMobColor " uniqueMobColor: " uniqueMobColor)
-    WriteLog(" playerOffset: " playerOffset)
-    WriteLog(" showWaypointLine: " showWaypointLine)
-    WriteLog(" showNextExitLine: " showNextExitLine)
-    WriteLog(" showBossLine: " showBossLine)
-    WriteLog(" gameWindowId: " gameWindowId)
-    WriteLog(" debug logging: " debug)
+    WriteLog("- baseUrl: " baseUrl)
+    WriteLog("- Map: global scale: " scale ", global top margin: " topMargin ", global left margin: " leftMargin ", opacity: " opacity)
+    WriteLog("- hideTown: " hideTown ", alwaysShowMap: " alwaysShowMap)
+    WriteLog("- playerOffset: " playerOffset)
+    WriteLog("- gameWindowId: " gameWindowId)
+    WriteLog("- debug logging: " debug)
+    if FileExist(A_Scriptdir . "\mapconfig.ini") {
+        WriteLog("Found existing mapconfig.ini")
+    }
+    WriteLog("Starting d2r-mapview...")
 
     if (!playerOffset) {
-        WriteLog("startingOffset not set, this is mandatory for this MH to function")
+        WriteLog("ERROR: startingOffset not set, this is mandatory for this MH to function")
         ExitApp
     }
 }

--- a/src/readSettings.ahk
+++ b/src/readSettings.ahk
@@ -18,6 +18,8 @@ readSettings(settingsFile, ByRef settings) {
     IniRead, showUniqueMobs, settings.ini, MapSettings, showUniqueMobs, "true"
     IniRead, showBosses, settings.ini, MapSettings, showBosses, "true"
     IniRead, showDeadMobs, settings.ini, MapSettings, showDeadMobs, "true"
+    IniRead, showOtherPlayers, settings.ini, MapSettings, showOtherPlayers, "true"
+    
     IniRead, normalMobColor, settings.ini, MapSettings, normalMobColor, "FFFFFF"
     IniRead, uniqueMobColor, settings.ini, MapSettings, uniqueMobColor, "D4AF37"
     IniRead, bossColor, settings.ini, MapSettings, bossColor, "FF0000"
@@ -49,6 +51,7 @@ readSettings(settingsFile, ByRef settings) {
     edges := edges = "true" ; convert to bool
     showNormalMobs := showNormalMobs = "true" ; convert to bool
     showUniqueMobs := showUniqueMobs = "true" ; convert to bool
+    showOtherPlayers := showOtherPlayers = "true"
     showWaypointLine := showWaypointLine = "true" ; convert to bool
     showNextExitLine := showNextExitLine = "true" ; convert to bool
     showBossLine := showBossLine = "true" ; convert to bool
@@ -70,6 +73,7 @@ readSettings(settingsFile, ByRef settings) {
     settings.Insert("showUniqueMobs", showUniqueMobs)
     settings.Insert("showBosses", showBosses)
     settings.Insert("showDeadMobs", showDeadMobs)
+    settings.Insert("showOtherPlayers", showOtherPlayers)
     settings.Insert("normalMobColor", normalMobColor)
     settings.Insert("uniqueMobColor", uniqueMobColor)
     settings.Insert("bossColor", bossColor)
@@ -93,10 +97,15 @@ readSettings(settingsFile, ByRef settings) {
     WriteLog(" hideTown: " hideTown ", alwaysShowMap: " alwaysShowMap)
     WriteLog(" showNormalMobs: " showNormalMobs " showUniqueMobs: " showUniqueMobs " showBosses: " showBosses " showDeadMobs: " showDeadMobs)
     WriteLog(" normalMobColor: " normalMobColor " uniqueMobColor: " uniqueMobColor)
-    WriteLog(" startingOffset: " startingOffset)
+    WriteLog(" playerOffset: " playerOffset)
     WriteLog(" showWaypointLine: " showWaypointLine)
     WriteLog(" showNextExitLine: " showNextExitLine)
     WriteLog(" showBossLine: " showBossLine)
     WriteLog(" gameWindowId: " gameWindowId)
     WriteLog(" debug logging: " debug)
+
+    if (!playerOffset) {
+        WriteLog("startingOffset not set, this is mandatory for this MH to function")
+        ExitApp
+    }
 }

--- a/src/settings.ini
+++ b/src/settings.ini
@@ -2,15 +2,12 @@
 baseUrl=http://diab.wikiwarsgame.com:8080
 
 [MapSettings]
-; maps are of various size, so for oversized maps the image size is reduced to maxWidth size
-maxWidth=2000
-
-; 'scale' this will scale the map image size, 1 being default scale.
-; the scale will be be capped by the 'maxWidth' value
-; choose a scale between 1 and 2
+; this scale is the global scale value and will affect ALL maps
+; each individual map has it's own scale value in mapconfig.ini
 scale=1.500000
 
-; position of map, in pixels
+; left and top margin which applies to ALL maps
+; each has it's own position relative to this, defined in mapconfig.ini
 leftMargin=20
 topMargin=20
 

--- a/src/settings.ini
+++ b/src/settings.ini
@@ -2,11 +2,11 @@
 baseUrl=http://diab.wikiwarsgame.com:8080
 
 [MapSettings]
-; this scale is the global scale value and will affect ALL maps
+; this scale is the GLOBAL scale value and will affect __ALL__ maps
 ; each individual map has it's own scale value in mapconfig.ini
-scale=1.500000
+scale=1.000000
 
-; left and top margin which applies to ALL maps
+; left and top margin which applies to __ALL__ maps
 ; each has it's own position relative to this, defined in mapconfig.ini
 leftMargin=20
 topMargin=20

--- a/src/ui/image/downloadMapImage.ahk
+++ b/src/ui/image/downloadMapImage.ahk
@@ -6,17 +6,19 @@ SetWorkingDir, %A_ScriptDir%
 downloadMapImage(settings, gameMemoryData, ByRef mapData) {
     baseUrl:= settings["baseUrl"]
     if (settings["edges"]) {
-        imageUrl := baseUrl . "/v1/map/" . gameMemoryData["mapSeed"] . "/" . gameMemoryData["difficulty"] . "/" . gameMemoryData["levelNo"] . "/image?trim=true&flat=true&edge=true"
+        imageUrl := baseUrl . "/v1/map/" . gameMemoryData["mapSeed"] . "/" . gameMemoryData["difficulty"] . "/" . gameMemoryData["levelNo"] . "/image?flat=true&edge=true"
     } else {
-        imageUrl := baseUrl . "/v1/map/" . gameMemoryData["mapSeed"] . "/" . gameMemoryData["difficulty"] . "/" . gameMemoryData["levelNo"] . "/image?trim=true&flat=true"
+        imageUrl := baseUrl . "/v1/map/" . gameMemoryData["mapSeed"] . "/" . gameMemoryData["difficulty"] . "/" . gameMemoryData["levelNo"] . "/image?flat=true"
     }
 
     sFile := A_Temp . "\" . gameMemoryData["mapSeed"] . "_" . gameMemoryData["difficulty"] . "_" . gameMemoryData["levelNo"] . ".png"
     FileDelete, %sFile%
 
     levelNo := gameMemoryData["levelNo"]
-    IniRead, levelScale, mapconfig.ini, %levelNo%, scale, 0.5
-    WriteLog("Read levelScale " levelScale " from file")
+    IniRead, levelScale, mapconfig.ini, %levelNo%, scale, 1.0
+    IniRead, levelxmargin, mapconfig.ini, %levelNo%, x, 0
+    IniRead, levelymargin, mapconfig.ini, %levelNo%, y, 0
+    ;WriteLog("Read levelScale " levelScale " " levelxmargin " " levelymargin " from file")
     try {
         whr := ComObjCreate("WinHttp.WinHttpRequest.5.1")
         WinHttpReq.SetTimeouts("60000", "60000", "60000", "60000")
@@ -80,5 +82,5 @@ downloadMapImage(settings, gameMemoryData, ByRef mapData) {
     if (FileExist(sFile)) {
         WriteLog("Downloaded " imageUrl " to " sFile)
     }
-    mapData := { "sFile": sFile, "leftTrimmed" : leftTrimmed, "topTrimmed" : topTrimmed, "levelScale": levelScale, "mapOffsetX" : mapOffsetX, "mapOffsety" : mapOffsety, "mapwidth" : mapwidth, "mapheight" : mapheight, "exits": exits, "waypoint": waypoint, "bosses": bosses }
+    mapData := { "sFile": sFile, "leftTrimmed" : leftTrimmed, "topTrimmed" : topTrimmed, "levelScale": levelScale, "levelxmargin": levelxmargin, "levelymargin": levelymargin, "mapOffsetX" : mapOffsetX, "mapOffsety" : mapOffsety, "mapwidth" : mapwidth, "mapheight" : mapheight, "exits": exits, "waypoint": waypoint, "bosses": bosses }
 } 

--- a/src/ui/image/downloadMapImage.ahk
+++ b/src/ui/image/downloadMapImage.ahk
@@ -6,14 +6,17 @@ SetWorkingDir, %A_ScriptDir%
 downloadMapImage(settings, gameMemoryData, ByRef mapData) {
     baseUrl:= settings["baseUrl"]
     if (settings["edges"]) {
-        imageUrl := baseUrl . "/v1/map/" . gameMemoryData["mapSeed"] . "/" . gameMemoryData["difficulty"] . "/" . gameMemoryData["levelNo"] . "/image?flat=true&edge=true"
+        imageUrl := baseUrl . "/v1/map/" . gameMemoryData["mapSeed"] . "/" . gameMemoryData["difficulty"] . "/" . gameMemoryData["levelNo"] . "/image?trim=true&flat=true&edge=true"
     } else {
-        imageUrl := baseUrl . "/v1/map/" . gameMemoryData["mapSeed"] . "/" . gameMemoryData["difficulty"] . "/" . gameMemoryData["levelNo"] . "/image?flat=true"
+        imageUrl := baseUrl . "/v1/map/" . gameMemoryData["mapSeed"] . "/" . gameMemoryData["difficulty"] . "/" . gameMemoryData["levelNo"] . "/image?trim=true&flat=true"
     }
 
     sFile := A_Temp . "\" . gameMemoryData["mapSeed"] . "_" . gameMemoryData["difficulty"] . "_" . gameMemoryData["levelNo"] . ".png"
     FileDelete, %sFile%
 
+    levelNo := gameMemoryData["levelNo"]
+    IniRead, levelScale, mapconfig.ini, %levelNo%, scale, 0.5
+    WriteLog("Read levelScale " levelScale " from file")
     try {
         whr := ComObjCreate("WinHttp.WinHttpRequest.5.1")
         WinHttpReq.SetTimeouts("60000", "60000", "60000", "60000")
@@ -77,5 +80,5 @@ downloadMapImage(settings, gameMemoryData, ByRef mapData) {
     if (FileExist(sFile)) {
         WriteLog("Downloaded " imageUrl " to " sFile)
     }
-    mapData := { "sFile": sFile, "leftTrimmed" : leftTrimmed, "topTrimmed" : topTrimmed, "mapOffsetX" : mapOffsetX, "mapOffsety" : mapOffsety, "mapwidth" : mapwidth, "mapheight" : mapheight, "exits": exits, "waypoint": waypoint, "bosses": bosses }
-}  
+    mapData := { "sFile": sFile, "leftTrimmed" : leftTrimmed, "topTrimmed" : topTrimmed, "levelScale": levelScale, "mapOffsetX" : mapOffsetX, "mapOffsety" : mapOffsety, "mapwidth" : mapwidth, "mapheight" : mapheight, "exits": exits, "waypoint": waypoint, "bosses": bosses }
+} 

--- a/src/ui/showMap.ahk
+++ b/src/ui/showMap.ahk
@@ -14,6 +14,11 @@ ShowMap(settings, mapData, gameMemoryData, ByRef uiData) {
     levelNo:= gameMemoryData["levelNo"]
     IniRead, levelScale, mapconfig.ini, %levelNo%, scale, 1.0
     scale := levelScale * scale
+    IniRead, levelxmargin, mapconfig.ini, %levelNo%, x, 0
+    IniRead, levelymargin, mapconfig.ini, %levelNo%, y, 0
+    leftMargin := leftMargin + levelxmargin
+    topMargin := topMargin + levelymargin
+
     ; WriteLog("maxGuiWidth := " maxGuiWidth)
     ; WriteLog("scale := " scale)
     ; WriteLog("leftMargin := " leftMargin)

--- a/src/ui/showMap.ahk
+++ b/src/ui/showMap.ahk
@@ -10,6 +10,10 @@ ShowMap(settings, mapData, gameMemoryData, ByRef uiData) {
     leftMargin:= settings["leftMargin"]
     topMargin:= settings["topMargin"]
     opacity:= settings["opacity"]
+    sFile := mapData["sFile"] ; downloaded map image
+    levelNo:= gameMemoryData["levelNo"]
+    IniRead, levelScale, mapconfig.ini, %levelNo%, scale, 1.0
+    scale := levelScale * scale
     ; WriteLog("maxGuiWidth := " maxGuiWidth)
     ; WriteLog("scale := " scale)
     ; WriteLog("leftMargin := " leftMargin)
@@ -30,10 +34,6 @@ ShowMap(settings, mapData, gameMemoryData, ByRef uiData) {
     serverScale := 2 
     Angle := 45
     padding := 150
-
-    sFile := mapData["sFile"] ; downloaded map image
-    ; FileGetSize, sFileSize, %sFile%
-    ; WriteLogDebug("Showing map " sFile " " sFileSize)
     If !pToken := Gdip_Startup()
     {
         MsgBox "Gdiplus failed to start. Please ensure you have gdiplus on your system"
@@ -52,19 +52,11 @@ ShowMap(settings, mapData, gameMemoryData, ByRef uiData) {
     Height := Gdip_GetImageHeight(pBitmap)
     Gdip_GetRotatedDimensions(Width, Height, Angle, RWidth, RHeight)
     Gdip_GetRotatedTranslation(Width, Height, Angle, xTranslation, yTranslation)
-    ; WriteLog("scale: " scale)
-    ; WriteLog("RWidth: " RWidth " RHeight: " RHeight)
 
     scaledWidth := (RWidth * scale)
-    scaleAdjust := 1 ; need to adjust the scale for oversized maps
-    if (scaledWidth > mapGuiWidth) {
-        scaleAdjust := mapGuiWidth / (RWidth * scale)
-        scaledWidth := mapGuiWidth
-        WriteLogDebug("Oversized map, reducing scale to " scale ", maxWidth set to " mapGuiWidth)
-    }
-    scaledHeight := (RHeight * 0.5) * scale * scaleAdjust
-    rotatedWidth := RWidth * scale * scaleAdjust
-    rotatedHeight := RHeight * scale * scaleAdjust
+    scaledHeight := (RHeight * 0.5) * scale
+    rotatedWidth := RWidth * scale
+    rotatedHeight := RHeight * scale
 
     hbm := CreateDIBSection(rotatedWidth, rotatedHeight)
     hdc := CreateCompatibleDC()
@@ -73,7 +65,6 @@ ShowMap(settings, mapData, gameMemoryData, ByRef uiData) {
     G := Gdip_GraphicsFromHDC(hdc)
     pBitmap := Gdip_RotateBitmap(pBitmap, Angle) ; rotates bitmap for 45 degrees. Disposes of pBitmap.
 
-    ;WriteLog("scaledWidth: " scaledWidth " scaledHeight: " scaledHeight)
     Gdip_DrawImage(G, pBitmap, 0, 0, scaledWidth, scaledHeight, 0, 0, RWidth, RHeight, opacity)
     UpdateLayeredWindow(hwnd1, hdc, leftMargin, topMargin, rotatedWidth, rotatedHeight)
     SelectObject(hdc, obm)
@@ -82,6 +73,6 @@ ShowMap(settings, mapData, gameMemoryData, ByRef uiData) {
     Gdip_DeleteGraphics(G)
     Gdip_DisposeImage(pBitmap)
     ElapsedTime := A_TickCount - StartTime
-    WriteLogDebug("Drew map " ElapsedTime " ms taken")
+    ;WriteLogDebug("Drew map " ElapsedTime " ms taken")
     uiData := { "scaledWidth": scaledWidth, "scaledHeight": scaledHeight, "sizeWidth": Width, "sizeHeight": Height }
 }

--- a/src/ui/showPlayer.ahk
+++ b/src/ui/showPlayer.ahk
@@ -16,6 +16,10 @@ ShowPlayer(settings, mapData, gameMemoryData, uiData) {
     levelNo:= gameMemoryData["levelNo"]
     IniRead, levelScale, mapconfig.ini, %levelNo%, scale, 1.0
     scale := levelScale * scale
+    IniRead, levelxmargin, mapconfig.ini, %levelNo%, x, 0
+    IniRead, levelymargin, mapconfig.ini, %levelNo%, y, 0
+    leftMargin := leftMargin + levelxmargin
+    topMargin := topMargin + levelymargin
     ; WriteLog("maxWidth := " maxWidth)
     ; WriteLog("leftMargin := " leftMargin)
     ; WriteLog("topMargin := " topMargin)
@@ -34,8 +38,8 @@ ShowPlayer(settings, mapData, gameMemoryData, uiData) {
     ; get relative position of player in world
     ; xpos is absolute world pos in game
     ; each map has offset x and y which is absolute world position
-    xPosDot := ((gameMemoryData["xPos"] - mapData["mapOffsetX"]) * serverScale) + padding - mapData["leftTrimmed"]
-    yPosDot := ((gameMemoryData["yPos"] - mapData["mapOffsetY"]) * serverScale) + padding - mapData["topTrimmed"]
+    xPosDot := ((gameMemoryData["xPos"] - mapData["mapOffsetX"]) * serverScale) + padding
+    yPosDot := ((gameMemoryData["yPos"] - mapData["mapOffsetY"]) * serverScale) + padding
     
 
     If !pToken := Gdip_Startup()
@@ -89,8 +93,8 @@ ShowPlayer(settings, mapData, gameMemoryData, uiData) {
         for index, mob in mobs
         {
             if (mob["mode"] == 0 or mob["mode"] == 12) { ; dead
-                mobx := ((mob["x"] - mapData["mapOffsetX"]) * serverScale) + padding - mapData["leftTrimmed"]
-                moby := ((mob["y"] - mapData["mapOffsetY"]) * serverScale) + padding - mapData["topTrimmed"]
+                mobx := ((mob["x"] - mapData["mapOffsetX"]) * serverScale) + padding
+                moby := ((mob["y"] - mapData["mapOffsetY"]) * serverScale) + padding
                 Gdip_DrawEllipse(G, pPenDead, mobx-1, moby-1, 2, 2)
             }
         }
@@ -101,8 +105,8 @@ ShowPlayer(settings, mapData, gameMemoryData, uiData) {
         {
             if (mob["isUnique"] == 0) {
                 if (mob["mode"] != 0 and mob["mode"] != 12) { ; not dead
-                    mobx := ((mob["x"] - mapData["mapOffsetX"]) * serverScale) + padding - mapData["leftTrimmed"]
-                    moby := ((mob["y"] - mapData["mapOffsetY"]) * serverScale) + padding - mapData["topTrimmed"]
+                    mobx := ((mob["x"] - mapData["mapOffsetX"]) * serverScale) + padding
+                    moby := ((mob["y"] - mapData["mapOffsetY"]) * serverScale) + padding
                     if (settings["showImmunities"]) {
                         immunities := mob["immunities"]
                         noImmunities := immunities["physical"] + immunities["magic"] + immunities["fire"] + immunities["light"] + immunities["cold"] + immunities["poison"]
@@ -149,8 +153,8 @@ ShowPlayer(settings, mapData, gameMemoryData, uiData) {
             if (settings["showBosses"]) {
                 if (mob["mode"] != 0 and mob["mode"] != 12) {
                     ;WriteLog("Boss: " mob["textTitle"])
-                    mobx := ((mob["x"] - mapData["mapOffsetX"]) * serverScale) + padding - mapData["leftTrimmed"]
-                    moby := ((mob["y"] - mapData["mapOffsetY"]) * serverScale) + padding - mapData["topTrimmed"]
+                    mobx := ((mob["x"] - mapData["mapOffsetX"]) * serverScale) + padding
+                    moby := ((mob["y"] - mapData["mapOffsetY"]) * serverScale) + padding
                     Gdip_DrawEllipse(G, pPenBoss, mobx-3, moby-3, 6, 6)
                 }
             }
@@ -159,8 +163,8 @@ ShowPlayer(settings, mapData, gameMemoryData, uiData) {
             if (settings["showUniqueMobs"]) {
                 if (mob["mode"] != 0 and mob["mode"] != 12) { ; not dead
                     ;WriteLog("Unique: " mob["textTitle"])
-                    mobx := ((mob["x"] - mapData["mapOffsetX"]) * serverScale) + padding - mapData["leftTrimmed"]
-                    moby := ((mob["y"] - mapData["mapOffsetY"]) * serverScale) + padding - mapData["topTrimmed"]
+                    mobx := ((mob["x"] - mapData["mapOffsetX"]) * serverScale) + padding
+                    moby := ((mob["y"] - mapData["mapOffsetY"]) * serverScale) + padding
                     if (settings["showImmunities"]) {
                         immunities := mob["immunities"]
                         noImmunities := immunities["physical"] + immunities["magic"] + immunities["fire"] + immunities["light"] + immunities["cold"] + immunities["poison"]
@@ -219,8 +223,8 @@ ShowPlayer(settings, mapData, gameMemoryData, uiData) {
         waypointHeader := mapData["waypoint"]
         if (waypointHeader) {
             wparray := StrSplit(waypointHeader, ",")
-            waypointX := (wparray[1] * serverScale) + padding - mapData["leftTrimmed"]
-            wayPointY := (wparray[2] * serverScale) + padding - mapData["topTrimmed"]
+            waypointX := (wparray[1] * serverScale) + padding
+            wayPointY := (wparray[2] * serverScale) + padding
             pPen := Gdip_CreatePen(0x55ffFF00, 3)
             Gdip_DrawLine(G, pPen, xPosDot, yPosDot, waypointX, wayPointY)
             Gdip_DeletePen(pPen)
@@ -236,8 +240,8 @@ ShowPlayer(settings, mapData, gameMemoryData, uiData) {
                 exitArray := StrSplit(A_LoopField, ",")
                 ;exitArray[1] ; id of exit
                 ;exitArray[2] ; name of exit
-                exitX := (exitArray[3] * serverScale) + padding - mapData["leftTrimmed"]
-                exitY := (exitArray[4] * serverScale) + padding - mapData["topTrimmed"]
+                exitX := (exitArray[3] * serverScale) + padding
+                exitY := (exitArray[4] * serverScale) + padding
 
                 ; only draw the line if it's a 'next' exit
                 if (isNextExit(gameMemoryData["levelNo"]) == exitArray[1]) {
@@ -255,8 +259,8 @@ ShowPlayer(settings, mapData, gameMemoryData, uiData) {
         if (bossHeader) {
             bossArray := StrSplit(bossHeader, ",")
             ;bossArray[1] ; name of boss
-            bossX := (bossArray[2] * serverScale) + padding - mapData["leftTrimmed"]
-            bossY := (bossArray[3] * serverScale) + padding - mapData["topTrimmed"]
+            bossX := (bossArray[2] * serverScale) + padding
+            bossY := (bossArray[3] * serverScale) + padding
 
             ; only draw the line if it's a 'next' exit
             pPen := Gdip_CreatePen(0xFFFF0000, 3)
@@ -270,8 +274,8 @@ ShowPlayer(settings, mapData, gameMemoryData, uiData) {
         pPen := Gdip_CreatePen(0xff00AA00, 4)
         for index, player in otherPlayers
         {
-            playerx := ((player["x"] - mapData["mapOffsetX"]) * serverScale) + padding - mapData["leftTrimmed"]
-            playery := ((player["y"] - mapData["mapOffsetY"]) * serverScale) + padding - mapData["topTrimmed"]
+            playerx := ((player["x"] - mapData["mapOffsetX"]) * serverScale) + padding
+            playery := ((player["y"] - mapData["mapOffsetY"]) * serverScale) + padding
             Gdip_DrawRectangle(G, pPen, playerx-2, playery-2, 4, 4)
         }
         Gdip_DeletePen(pPen)    


### PR DESCRIPTION
Map position changes:

- Now each level keeps it's own position and scale on the screen.
- You can change the scale with `Numpad+` and `Numpad-`, (you can configure different keys)
- To _move_ the map, press `Windows Key+Left` `Windows Key+Right` `Windows Key+Up` `Windows Key+Down`
- Map movement keys are not yet configurable
- Map location and scale for each map are saved in a new file `mapconfig.ini`
- The first time you run this version, a new `mapconfig.ini` file will be created with default values.
- If you have an existing `mapconfig.ini` it will not be overwritten, so you can keep your settings for future releases.
- The default values are not ideal, but in the next release I'll include better defaults (I need someone to manually configure every map)
- Normal `scale` and `leftMargin`/`topMargin` settings in `settings.ini` still work but will apply to ALL maps.  
  The individual map scale and location are relative to these values.  
  So if you set global scale `1.5` and an individual map scale is `1.2` then the actual scale is `1.5 x 1.2` (1.8).  

Other changes:

- Removed `maxWidth` setting as it didn't make sense anymore  
- Added the ability to turn off other players on the map `showOtherPlayers=true` in `settings.ini`
- Other minor tweaks for performance