### PR TITLE
typo Monste'r's missed 'r'

### DIFF
--- a/src/localization.ahk
+++ b/src/localization.ahk
@@ -31,7 +31,7 @@ LoadLocalization(ByRef settings) {
     localizedStringsShrines := ReadSection(locale, "Shrines")
     localizedStringsAreas := ReadSection(locale, "Areas")
     localizedStringsItems := ReadSection(locale, "Items")
-    localizedStringsMonstes := ReadSection(locale, "Monsters")
+    localizedStringsMonsters := ReadSection(locale, "Monsters")
     localizedStringsRunes := ReadSection(locale, "Runes")
     localizedStringsBuffs := ReadSection(locale, "Buffs")
     localizedStringsUI := ReadSection(locale, "UI")


### PR DESCRIPTION
(typo Monste'r's missed 'r')

/src/localization.ahk
#34 localizedStringMonstes -> localizedStringMonsters